### PR TITLE
bugfix/adjust-mono-logic-for-missing-attrs

### DIFF
--- a/svg-join.js
+++ b/svg-join.js
@@ -155,6 +155,9 @@ async function asyncMain () {
 
         if (argv.mono) {
           const styled_children = doc.children.filter(x => {
+            if (!x.attr) {
+              return false;
+            }
             let keys = Object.keys(x.attr)
             if (x.attr.style) keys = keys.concat(style_keys(x.attr.style))
             return keys.some(y => presentation.has(y))


### PR DESCRIPTION
Received 'Cannot convert undefined or null to object' error when trying to process the following svg.

`<svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg">
<path d="M39 21.666H36.27C35.4593 18.5265 33.7844 15.6773 31.4354 13.4422C29.0863 11.2071 26.1575 9.67566 22.9816 9.02195C19.8057 8.36823 16.5102 8.61844 13.4694 9.74413C10.4286 10.8698 7.76451 12.8259 5.77987 15.39C3.79523 17.9541 2.5696 21.0235 2.24225 24.2494C1.91491 27.4753 2.49897 30.7284 3.92807 33.6389C5.35717 36.5495 7.57401 39.0008 10.3267 40.7144C13.0794 42.428 16.2575 43.3351 19.5 43.3327H39C41.8731 43.3327 44.6286 42.1913 46.6603 40.1597C48.6919 38.128 49.8333 35.3725 49.8333 32.4993C49.8333 29.6262 48.6919 26.8707 46.6603 24.839C44.6286 22.8074 41.8731 21.666 39 21.666Z" stroke="#6B7479" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
</svg>
`